### PR TITLE
chore: update GitHub repository references to linuxfoundation org

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,4 +11,4 @@ The following versions are currently being supported with security updates.
 
 ## Reporting a Vulnerability
 
-To report a vulnerability, create a new [GitHub issue](https://github.com/communitybridge/easycla-landing-page/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc).
+To report a vulnerability, create a new [GitHub issue](https://github.com/linuxfoundation/easycla-landing-page/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc).


### PR DESCRIPTION
- Update SECURITY.md to reference linuxfoundation/easycla-landing-page
- Migrate repository URL from communitybridge to linuxfoundation organization

Addresses: https://github.com/linuxfoundation/easycla/issues/4742

Assisted by [Cursor](https://cursor.com/)
Signed-off-by: ahmedomosanya <aopeyemi@contractor.linuxfoundation.org>
